### PR TITLE
 Simplify docker volume configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ COPY --from=build /build /opt/rimworld-together
 # Set restrictive permissions on GameServer executable
 RUN chmod 750 /opt/rimworld-together/GameServer
 
+# Set the working directory
+WORKDIR /opt/rimworld-together/Data
+
 # Initialize the server by running it once during the build and passing "quit" to close it
 RUN echo "quit" | /opt/rimworld-together/GameServer || true
 
@@ -32,18 +35,7 @@ RUN echo "quit" | /opt/rimworld-together/GameServer || true
 EXPOSE 25555
 
 # Expose each of the persistent directories
-VOLUME ["/opt/rimworld-together/Backups"]
-VOLUME ["/opt/rimworld-together/Caravans"]
-VOLUME ["/opt/rimworld-together/Core"]
-VOLUME ["/opt/rimworld-together/Events"]
-VOLUME ["/opt/rimworld-together/Factions"]
-VOLUME ["/opt/rimworld-together/Logs"]
-VOLUME ["/opt/rimworld-together/Maps"]
-VOLUME ["/opt/rimworld-together/Saves"]
-VOLUME ["/opt/rimworld-together/Settlements"]
-VOLUME ["/opt/rimworld-together/Sites"]
-VOLUME ["/opt/rimworld-together/Users"]
+VOLUME ["/opt/rimworld-together/Data"]
 
-# Set the working directory and entrypoint
-WORKDIR /opt/rimworld-together
+#Set the entry point
 ENTRYPOINT ["/opt/rimworld-together/GameServer"]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ To start the game server using Docker Compose, navigate to the directory where t
 ```bash
 docker-compose up -d
 ```
+or
+```bash
+docker compose up -d
+```
+if using docker-compose-v2
 
 ### Container Updates
 To update the game server to a new version, you will need to pull the latest image (`docker-compose pull`) and restart the container (`docker-compose up -d`).
@@ -71,7 +76,6 @@ You can view real-time logs of the game server by running `docker-compose logs -
 
 
 ## Running the Game Server on Unraid
-
 You can easily deploy the Rimworld Together game server on Unraid using the provided Unraid app template. Follow the steps here ([unraid-template/README.md](unraid-template/README.md)) to install and configure the game server.
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,8 @@ services:
     ports:
       - "25555:25555"  # Map port 25555 from host to container
     volumes:
-      - /opt/rimworld-together/Backups
-      - /opt/rimworld-together/Caravans
-      - /opt/rimworld-together/Core
-      - /opt/rimworld-together/Events
-      - /opt/rimworld-together/Factions
-      - /opt/rimworld-together/Logs
-      - /opt/rimworld-together/Maps
-      - /opt/rimworld-together/Saves
-      - /opt/rimworld-together/Settlements
-      - /opt/rimworld-together/Sites
-      - /opt/rimworld-together/Users
+      - data:/opt/rimworld-together/Data
     restart: unless-stopped  # Automatically restart the container if it stops
+
+volumes:
+  data:

--- a/unraid-template/README.md
+++ b/unraid-template/README.md
@@ -31,39 +31,9 @@ This Unraid app template allows you to easily install and run the **Rimworld Tog
 
 #### Volume Mappings:
 Make all volumes read/write
-- **Backups**: Path to store game backups.
-  - Container Path: `/opt/rimworld-together/Backups`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Backups`.
-- **Caravans**: Path for caravans.
-  - Container Path: `/opt/rimworld-together/Caravans`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Caravans`.
-- **Core**: Path for most configuration files.
-  - Container Path: `/opt/rimworld-together/Core`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Core`.
-- **Events**: Path for game events.
-  - Container Path: `/opt/rimworld-together/Events`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Events`.
-- **Factions**: Path for factions.
-  - Container Path: `/opt/rimworld-together/Factions`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Factions`.
-- **Logs**: Path for logs.
-  - Container Path: `/opt/rimworld-together/Logs`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Logs`.
-- **Maps**: Path for saved maps.
-  - Container Path: `/opt/rimworld-together/Maps`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Maps`.
-- **Saves**: Path for saved games.
-  - Container Path: `/opt/rimworld-together/Saves`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Saves`.
-- **Settlements**: Path for settlements.
-  - Container Path: `/opt/rimworld-together/Settlements`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Settlements`.
-- **Sites**: Path for sites.
-  - Container Path: `/opt/rimworld-together/Sites`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Sites`.
-- **Users**: Path for user data.
-  - Container Path: `/opt/rimworld-together/Users`
-  - Default Host Path: `/mnt/user/appdata/rimworld-together/Users`.
+- **Data**: Path to store saved data and configs.
+  - Container Path: `/opt/rimworld-together/Data`
+  - Default Host Path: `/mnt/user/appdata/rimworld-together/Data`.
 
 ### 4. Start the Container
 


### PR DESCRIPTION
Changed the workdir of the server to /opt/rimworld-together/data to simplify docker volume configuration.